### PR TITLE
void-docs.1: Create.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 book/
 mandoc/
 void-docs.7
+void-docs

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 book/
 mandoc/
-void-docs.7
+void-docs.1
 void-docs

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 book/
 mandoc/
-void-docs.1
 void-docs

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ the same protocol as the packages tree. For details, please read
 ## Building
 
 The [build.sh](./build.sh) script builds HTML and roff versions of the Void
-documentation and the `void-docs.7` man page. It requires the following
+documentation and the `void-docs.1` man page. It requires the following
 dependencies:
 
 - `mdBook`

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 # Build HTML mdbook
 echo "Building mdBook"
 mdbook build
@@ -20,5 +22,5 @@ cd -
 # Build reference man page
 echo "Building void-docs man page"
 pandoc \
-    -V "title=void-docs" -V "section=7" -V "header=Void Docs" -s \
-    -o "void-docs.7" "void-docs.md"
+    -V "title=void-docs" -V "section=1" -V "header=Void Docs" -s \
+    -o "void-docs.1" "void-docs.md"

--- a/install.sh
+++ b/install.sh
@@ -1,19 +1,21 @@
 #!/bin/sh
 
+set -e
+
 PREFIX=$1
 DESTDIR=$2
 DOC=${DESTDIR}${PREFIX}/share/doc/void
 mkdir -p $DOC/
 
 cp -r src/ $DOC/markdown
-rm -r $DOC/markdown/theme
+rm -fr $DOC/markdown/theme
 
 cp -r book/html $DOC/html
 
 cp -r mandoc/ $DOC/mandoc
 
-mkdir -p ${DESTDIR}${PREFIX}/share/man/man7/
-install -m0644 void-docs.7 ${DESTDIR}${PREFIX}/share/man/man7/
+mkdir -p ${DESTDIR}${PREFIX}/share/man/man1/
+install -m0644 void-docs.1 ${DESTDIR}${PREFIX}/share/man/man1/
 
 sed -e "s,@PREFIX@,$PREFIX," void-docs.in > void-docs
 mkdir -p ${DESTDIR}${PREFIX}/bin/

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 
-DESTDIR=$1
-DOC=$DESTDIR/usr/share/doc/void
+PREFIX=$1
+DESTDIR=$2
+DOC=${DESTDIR}${PREFIX}/share/doc/void
 mkdir -p $DOC/
 
 cp -r src/ $DOC/markdown
@@ -11,5 +12,9 @@ cp -r book/html $DOC/html
 
 cp -r mandoc/ $DOC/mandoc
 
-mkdir -p $DESTDIR/usr/share/man/man7/
-install -m0644 void-docs.7 $DESTDIR/usr/share/man/man7/
+mkdir -p ${DESTDIR}${PREFIX}/share/man/man7/
+install -m0644 void-docs.7 ${DESTDIR}${PREFIX}/share/man/man7/
+
+sed -e "s,@PREFIX@,$PREFIX," void-docs.in > void-docs
+mkdir -p ${DESTDIR}${PREFIX}/bin/
+install -m0755 void-docs ${DESTDIR}${PREFIX}/bin/

--- a/void-docs.1
+++ b/void-docs.1
@@ -1,0 +1,162 @@
+.Dd August 1, 2020
+.Dt VOID-DOCS 1
+.Os
+.Sh NAME
+.Nm void-docs
+.Nd Access Void Linux documentation
+.Sh SYNOPSIS
+.Nm
+.Op OPTIONS
+.Op search terms
+.Sh DESCRIPTION
+The
+.Nm
+utility will attempt to launch different programs until it can find an
+adequate one to display the Void Linux documentation. If it is invoked
+without a search term, it will show the documentation's home
+page. Multiple search terms can be used to filter results. If the user
+has the
+.Xr fzf 1
+utility installed in their system, it will be used to browse the
+results. Otherwise,
+.Nm
+will display the first search result. If the
+.Fl s
+flag is used,
+.Nm
+will display the search results instead of the documentation.
+
+The programs
+.Nm
+will try to use are, in order of preference:
+.Bl -dash
+.It
+For the HTML version:
+.Bl -dash
+.It
+the program specified in the environment variable
+.Ev BROWSER .
+.It
+.Xr xdg-open 1
+if either the
+.Ev DISPLAY
+or
+.Ev WAYLAND_DISPLAY
+environment variable is set.
+.It
+the TUI browsers
+.Xr lynx 1 ,
+.Xr w3m 1 ,
+and
+.Xr links 1  .
+.El
+.It
+For the Markdown version:
+.Bl -dash
+.It
+the Markdown processors
+.Sq mdcat
+and
+.Sq glow .
+.El
+.It
+For the roff (mdoc) version:
+.Bl -dash
+.It
+.Xr man 1
+.El
+.El
+.Pp
+For a better browsing experience, installing
+.Xr fzf 1
+is recommended.
+.Sh OPTIONS
+.Bl -tag -width -x
+.It Fl h, Fl -help
+Show help message.
+.It Fl b
+Only try to display the HTML version.
+.It Fl m
+Only try to display the Markdown version.
+.It Fl r
+Only try to display the roff (mdoc) version.
+.It Fl s
+Only display search results.
+.El
+.Sh FILES
+The
+.Sq void-docs
+package contains a snapshot of the online documentation from
+.Lk https://docs.voidlinux.org ,
+which intends to document installation, configuration and system
+management for Void Linux. It is packaged in three formats.
+.Bl -tag -width x
+.It Pa /usr/share/doc/void/html/*
+Documentation in HTML format. Can be viewed with any browser, such as
+Mozilla Firefox or Chromium. Recommended when a GUI session is
+available, because it allows easy navigation between the documentation
+pages and has the same format as the official website. Can be accessed
+by pointing a browser to
+.Pa /usr/share/doc/void/html/index.html .
+.It Pa /usr/share/doc/void/markdown/*
+Documentation in Markdown format. Can be viewed as text files, using
+.Xr cat 1
+or
+.Xr less 1 ,
+or as formatted Markdown files, using applications such as
+.Sq mdcat
+or
+.Sq glow .
+The table of contents can be accessed via the
+.Pa /usr/share/doc/void/markdown/SUMMARY.md
+file.
+.It Pa /usr/share/doc/void/mandoc/*
+Documentation in roff (mdoc) format. Can be viewed using
+.Xr mandoc 1 .
+Using
+.Xr mandoc 1
+with the
+.Fl a
+option, which enables a pager, is recommended.
+.Sh EXAMPLES
+View the documentation page about the kernel:
+.Pp
+.Dl $ void-docs kernel
+.Pp
+View a documentation page inside another session:
+.Pp
+.Dl $ void-docs graphical-session kde
+.Pp
+View the homepage of the HTML documentation with
+.Xr qutebrowser 1 :
+.Pp
+.Dl $ qutebrowser /usr/share/doc/void/html/index.html
+.Pp
+View the summary of the Markdown documentation with
+.Xr less 1 :
+.Pp
+.Dl $ less /usr/share/doc/void/markdown/SUMMARY.md
+.Pp
+View the
+.Dq Kernel
+page of the Markdown documentation with
+.Sq mdcat :
+.Pp
+.Dl $ mdcat /usr/share/doc/void/markdown/config/kernel.md
+.Pp
+View the
+.Dq Cron
+page of the roff (mdoc) documentation with
+.Xr mandoc 1 :
+.Pp
+.Dl $ mandoc -a /usr/share/doc/void/mandoc/config/cron.7
+.Pp
+.Sh AVAILABILITY
+This man page is part of the void-docs package and is available from
+.Lk https://github.com/void-linux/void-docs .
+.Sh BUGS
+The Void Linux documentation tries to limit itself to content that is
+specific to Void. Therefore, if you feel something is missing, it
+might have been deliberate. However, if there is any information that
+is mistaken, outdated or indeed missing, please report an issue at
+.Lk https://github.com/void-linux/void-docs .

--- a/void-docs.in
+++ b/void-docs.in
@@ -1,0 +1,145 @@
+#!/bin/sh
+# This is the void linux documentation browser
+
+[ "$DEBUG" ] && set -x
+# turn on errors and noglob
+set -fe
+
+# document to open
+VOIDDOC=
+# terms to search for
+TERMS=
+# versions to try
+_html=1
+_md=1
+_roff=1
+
+usage() {
+    cat <<EOF
+Welcome to the Void Linux documentation browser!
+
+Usage: $0 [options] [search terms]
+
+Options:
+-h, --help: show this help text
+-b: only try to display the HTML version
+-m: only try to display the Markdown version
+-r: only try to display the roff (mandoc) version
+-s: only display search results
+EOF
+
+    exit 0
+}
+
+while [ $# -gt 0 ]; do
+    case $1 in
+        -h|--help) usage ;;
+        -b) _html=1 ; _md= ; _roff= ;;
+        -m) _html= ; _md=1 ; _roff= ;;
+        -r) _html= ; _md= ; _roff=1 ;;
+        -s) _search=1 ;;
+        *)
+            if [ "$TERMS" ]; then
+                TERMS="$TERMS -and -iwholename *$1*"
+            else
+                TERMS="-iwholename *$1*"
+            fi
+            ;;
+    esac
+    shift
+done
+
+: "${DOCS:=@PREFIX@/share/doc/void}"
+
+# creates the appropriate path
+find_page() {
+    case $1 in
+        html) VOIDDOC="$DOCS/html/$2.html" ;;
+        md) VOIDDOC="$DOCS/markdown/$2.md" ;;
+        man) VOIDDOC="$DOCS/mandoc/$2.7" ;;
+    esac
+
+    if [ -f "$VOIDDOC" ]; then
+        echo "$VOIDDOC"
+    else
+        echo "couldn't find file" >&2
+        return 1
+    fi
+}
+
+# knows how to open a certain page
+open_page() {
+    if [ "$_html" ]; then
+        if [ -n "$BROWSER" ] && command -v $BROWSER >/dev/null; then
+            page=$(find_page html $1)
+            exec $BROWSER $page
+        fi
+
+        # check if wayland or X session
+        if [ -n "$WAYLAND_DISPLAY" -o -n "$DISPLAY" ] && command -v xdg-open >/dev/null; then
+            page=$(find_page html $1)
+            exec xdg-open $page
+        fi
+
+        # if a browser or xdg-open weren't available, we can try other stuff
+
+        # cli browser
+        for viewer in lynx w3m links
+        do
+            if command -v $viewer >/dev/null; then
+                page=$(find_page html $1)
+                exec $viewer $page
+            fi
+        done
+    fi
+
+    if [ "$_md" ]; then
+        # markdown processor
+        for viewer in mdcat glow
+        do
+            if command -v $viewer >/dev/null; then
+                page=$(find_page md $1)
+                $viewer $page | less -R
+                exit
+            fi
+        done
+    fi
+
+    if [ "$_roff" ]; then
+        # otherwise go for the man page
+        page=$(find_page man $1)
+        exec man -l $page
+    fi
+
+    echo "Couldn't find a program to display the documentation."
+    return 1
+}
+
+search_page() {
+    file="$(find $DOCS/markdown -type f $1 -printf "%P\n")"
+    [ -z "$file" ] && exit 1
+
+    if [ "$_search" ]; then
+        echo "$file"
+        return 0
+    fi
+
+    if command -v fzf >/dev/null; then
+        file="$(echo "$file" | fzf -1)"
+        [ -z "$file" ] && exit 1
+    else
+        file="$(echo "$file" | head -1)"
+    fi
+    file="${file%.md}"
+    echo $file
+}
+
+page=about/index
+[ "$TERMS" ] && page="$(search_page "$TERMS")"
+
+if [ "$_search" ]; then
+    echo "$page"
+    exit 0
+fi
+
+open_page "$page"

--- a/void-docs.md
+++ b/void-docs.md
@@ -1,21 +1,80 @@
 # NAME
 
-void-docs - Void Linux documentation package
+void-docs - Void Linux documentation
 
 # SYNOPSIS
+
+**void-docs** [**OPTIONS**] [search terms]
+
+# DESCRIPTION
+
+The **void-docs** utility will attempt to launch different programs until it can
+find an adequate one to display the Void Linux documentation. If it is invoked
+without a search term, it will show the documentation's home page. Multiple
+search terms can be used to filter results. If the user has the **fzf(1)**
+utility installed in their system, it will be used to browse the results.
+Otherwise, **void-docs** will display the first search result. If the **-s**
+flag is used, **void-docs** will display the search results instead of the
+documentation.
+
+**void-docs** supports some command line flags:
+
+**-h, --help**: show help dialog
+
+**-b**: only try to display the HTML version
+
+**-m**: only try to display the Markdown version
+
+**-r**: only try to display the roff (mandoc) version
+
+**-s**: only display search results
+
+The programs **void-docs** is aware of and will try to use are, in order of
+preference:
+
+For the HTML version:
+
+- the program specified in the environment variable *BROWSER*
+- **xdg-open(1)** if either *DISPLAY* or *WAYLAND_DISPLAY* environment variables
+   are set
+- the TUI browsers **lynx(1)**, **w3m(1)** and **links(1)**
+
+For the Markdown version:
+
+- the Markdown processors **mdcat** and **glow**
+
+For the **roff(7)** version:
+
+- **man(1)**
+
+For a better browsing experience, it is recommended to install **fzf(1)**.
+
+## EXAMPLES
+
+Viewing the documentation page about the kernel:
+
+```
+$ void-docs kernel
+```
+
+Viewing a documentation page inside another session:
+
+```
+$ void-docs graphical-session kde
+```
+
+# FILES
+
+The `void-docs` package contains a snapshot of the online documentation from
+https://docs.voidlinux.org, which intends to document installation,
+configuration and system management for Void Linux. It is packaged in three
+formats.
 
 */usr/share/doc/void/html* - documentation in HTML format
 
 */usr/share/doc/void/markdown* - documentation in Markdown format
 
 */usr/share/doc/void/mandoc* - documentation in roff format
-
-# DESCRIPTION
-
-The `void-docs` package contains a snapshot of the online documentation from
-https://docs.voidlinux.org, which intends to document installation,
-configuration and system management for Void Linux. It is packaged in three
-formats.
 
 */usr/share/doc/void/html* - can be viewed with any browser, such as Mozilla
 Firefox or Chromium. Recommended when a GUI session is available, because it
@@ -31,7 +90,7 @@ or **less(1)**, or as formatted markdown files, with applications such as
 */usr/share/doc/void/mandoc* - can be viewed using **mandoc(1)**. Using
 **mandoc(1)** with the **-a** option, which enables a pager, is recommended.
 
-# EXAMPLES
+## EXAMPLES
 
 Viewing the homepage of the HTML documentation with **qutebrowser(1)**:
 


### PR DESCRIPTION
This PR:

* restructures the void-docs(1) man page to follow mdoc(7) conventions;
* uses semantic markup as much as possible (e.g. for references to man pages, file paths, URLs, env vars, etc.);
* changes references to "mandoc" to "mdoc" where appropriate (mandoc is the program, mdoc is the format);
* makes some phrasing changes.

LMKWYT.